### PR TITLE
ci: update actions to their current majors

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -7,6 +7,8 @@ on:
 
 permissions:
   contents: read
+  # deploy-pages needs actions: read to fetch the build artifact.
+  actions: read
   pages: write
   id-token: write
 
@@ -18,17 +20,17 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           # The build stamps "Last updated" from git history per page.
           fetch-depth: 0
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v7
         with:
           node-version: 22
           cache: npm
       - run: npm ci
       - run: node scripts/build.mjs
-      - uses: actions/upload-pages-artifact@v3
+      - uses: actions/upload-pages-artifact@v5
         with:
           path: _site
 
@@ -40,4 +42,4 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5


### PR DESCRIPTION
Every action in this workflow was several majors behind, which is how the Node 20 deprecation warnings appeared.

| Action | Was | Now |
| --- | --- | --- |
| actions/checkout | v4 | v7 |
| actions/setup-node | v4 | v7 |
| actions/upload-pages-artifact | v3 | v5 |
| actions/deploy-pages | v4 | v5 |

Also adds the `actions: read` permission that deploy-pages documents as required from v4 onward; it was missing, and deploys happened to work without it.

Checked for breaking changes rather than assuming: upload-pages-artifact v4 stopped including dotfiles, so the generated `.nojekyll` no longer ships. That is inert here, because the Actions deployment flow does not run Jekyll and the built site has no underscore-prefixed paths. setup-node's caching changes across v5 and v6 do not apply since `cache: npm` is set explicitly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)