### PR TITLE
fix: advance the root effective date with the Cueprise page change

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Terms of Service
 
-**Effective date: 16 August 2026**
+**Effective date: 17 August 2026**
 
 These Terms of Service ("Terms") govern your access to and use of the
 websites and programmes operated by **Cuesoft Inc.** (a Delaware


### PR DESCRIPTION
The root document promises "the effective date above changes with it" whenever the terms change. terms#7 changed the Cueprise Platform Terms on 17 August; the root still said 16 August, violating its own promise. Same class as the finding Codex caught on privacy-policy#10, missed here by all of us.

🤖 Generated with [Claude Code](https://claude.com/claude-code)