### PR TITLE
content: the EU ODR platform closed, point at ADR bodies instead

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Terms of Service
 
-**Effective date: 17 August 2026**
+**Effective date: 21 August 2026**
 
 These Terms of Service ("Terms") govern your access to and use of the
 websites and programmes operated by **Cuesoft Inc.** (a Delaware

--- a/jurisdictions/eu-uk/README.md
+++ b/jurisdictions/eu-uk/README.md
@@ -33,12 +33,15 @@ EU/EEA or UK:
   [refund terms](../../programmes/cueta/) operate alongside it, and the
   more protective provision prevails.
 
-## Online dispute resolution
+## Out-of-court dispute resolution
 
-EU consumers can also use the European Commission's Online Dispute
-Resolution platform at
-[ec.europa.eu/consumers/odr](https://ec.europa.eu/consumers/odr/). Our
-contact for it is [hello@cuesoft.io](mailto:hello@cuesoft.io).
+The European Commission's Online Dispute Resolution platform closed on
+20 July 2025 under Regulation (EU) 2024/3228. EU consumers can find an
+approved out-of-court dispute resolution body for their country through
+the Commission's Consumer Redress portal at
+[consumer-redress.ec.europa.eu](https://consumer-redress.ec.europa.eu/dispute-resolution-bodies).
+Our contact for any such procedure is
+[hello@cuesoft.io](mailto:hello@cuesoft.io).
 
 ## Privacy
 


### PR DESCRIPTION
The EU/UK terms told consumers they could use the European Commission's Online Dispute Resolution platform. **That platform was discontinued on 20 July 2025** under Regulation (EU) 2024/3228, so the clause has been wrong for over a year.

Verified against the Commission's own relocation notice, which states it plainly: *"The European Online Dispute Resolution (ODR) Platform is discontinued as of 20 July 2025."* The old link still returns 200 but redirects to that notice, not to anything a consumer can use.

**Updating the URL alone would not have fixed it.** The successor is a Consumer Redress portal listing approved ADR bodies, which is a different thing from a platform you file a dispute on. The clause now says the platform closed and points at the list of approved out-of-court bodies, which is where the Commission's own notice directs people.

The trader obligation to link the ODR platform was repealed along with it, so this section is now a voluntary signpost rather than a compliance requirement. Keeping it because it is genuinely useful to an EU consumer.

Root effective date advanced from 17 to 21 August 2026, per the promise in the root README that it changes whenever the Terms do.

Checked: `npm run build` renders 16 pages cleanly, the new link appears in the built output, and no `consumers/odr` reference remains anywhere in the repo. Both the portal root and the ADR bodies list return 200.

Separately noted, not changed here: this repo's legal text also contains em dashes, which the brand rule bans in shipped copy. Left alone deliberately, since rewording legal wording needs more care than a copy sweep and it was outside the scope approved for the websites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)