### PR TITLE
content: CueLABS internships run three or six months

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Terms of Service
 
-**Effective date: 21 August 2026**
+**Effective date: 22 August 2026**
 
 These Terms of Service ("Terms") govern your access to and use of the
 websites and programmes operated by **Cuesoft Inc.** (a Delaware

--- a/programmes/cuelabs/README.md
+++ b/programmes/cuelabs/README.md
@@ -23,7 +23,7 @@ governs each internship and prevails over this page wherever they differ.
 2. **Data allowance.** Cuesoft covers interns' connectivity costs through
    a monthly data allowance stated in the internship agreement.
 3. **Term and notice.** Internships run for the fixed term stated in the
-   agreement (typically six months) and either party may end one on the
+   agreement, three or six months, and either party may end one on the
    notice the agreement states.
 4. **What interns get.** Supervised production experience on live,
    MIT-licensed products with public commit histories under the intern's


### PR DESCRIPTION
`programmes/cuelabs/README.md` said internships run "the fixed term stated in the agreement (typically six months)". Both 3 and 6 month terms are offered, per owner ruling 2026-08-22 and `cuelabs-website/src/app/api/apply/route.ts:88`. Same defect as the handbook's, in the published Terms.

Effective date advanced to 22 August 2026.

**One instruction I did not carry out, deliberately.** I was asked to consider adding `talent.cuesoft.io` to the "Websites" definition, since it receives mail via Lark and is not listed. It should not be added: it has no A, AAAA or CNAME record. `Pulumi.cloudflare.yaml` declares only MX and TXT for it, and a live `dig` confirms all three address record types return empty. It is a mail-only domain, the work-email domain issued to personnel at hire. Putting it in a definition of "Websites" would make the Terms untrue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)