### PR TITLE
Make the Cueprise terms cover the website as well as the platform

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ under a signed agreement or invoice.
 | --- | --- |
 | [Using the Websites](websites/) | Acceptable use, content, third-party links, and [Ace](websites/ace/). |
 | Programmes | [CueTA™](programmes/cueta/), [CueLABS™](programmes/cuelabs/), [CueHIRE™](programmes/cuehire/) and the [media properties](programmes/media/). |
-| [Cueprise™ Platform Terms](cueprise/) | A standalone document for our licensed enterprise platform and its authorised users. |
+| [Cueprise™ Terms](cueprise/) | A standalone document covering the Cueprise™ website and the licensed platform behind it. |
 | Legal terms | [Intellectual property](legal/intellectual-property/), [confidentiality](legal/confidentiality/), [liability](legal/liability/), [termination and force majeure](legal/termination/), and the [general clauses](legal/general/). |
 | Jurisdictions | Your governing law and forum in [Nigeria](jurisdictions/nigeria/), the [United States](jurisdictions/united-states/) and the [EU/UK](jurisdictions/eu-uk/). |
 

--- a/cueprise/README.md
+++ b/cueprise/README.md
@@ -1,18 +1,43 @@
-# Cueprise™ Platform Terms
+# Cueprise™ Terms
 
-**Effective date: 17 August 2026**
+**Effective date: 28 August 2026**
 
-These Platform Terms govern access to and use of **Cueprise™**, Cuesoft's
-enterprise business management platform. Cueprise™ is licensed to
-organisations ("**Licensees**") under separate written licensing
-agreements; nothing on the Websites grants any licence to Cueprise™.
+These terms cover **Cueprise™** in both the places you meet it: the website
+at **cueprise.cuesoft.io**, where you can read about the product and ask for
+a demo, and the **platform** itself, which is licensed to organisations
+("**Licensees**") under separate written licensing agreements.
+
+The distinction matters, because nothing on the website grants any licence to
+Cueprise™. Reading the site, asking for a demo and being given a walkthrough
+create no right to use the platform; that starts only with a signed agreement.
 
 **Order of precedence.** For any conflict, the signed licensing agreement
-(including its order forms and data terms) prevails over these Platform
-Terms, which prevail over the general
-[Terms of Service](../) for matters concerning the platform.
+(including its order forms and data terms) prevails over the Platform Terms
+below, which prevail over the general [Terms of Service](../) for matters
+concerning the platform.
 
-## Access and authorised users
+## The Cueprise™ website
+
+- **What the site is for.** cueprise.cuesoft.io describes the product and
+  lets you ask for a demonstration. Descriptions of features, modules and
+  integrations are provided in good faith and may change as the product
+  does; they are not a specification and not a promise of a particular
+  outcome for your business.
+- **A demo request starts a conversation, nothing more.** Submitting the
+  form creates no contract and no obligation on either side. No fee is
+  quoted on the site: a Cueprise™ licence is priced after a conversation.
+- **No payment is ever taken on the site.**
+- **Acceptable use, and everything else about using the site**, is governed
+  by [Using the Websites](../websites/), which applies to cueprise.cuesoft.io
+  exactly as it does to our other sites.
+- **What we do with what you submit** is set out in the
+  [Cueprise™ Privacy Notice](https://privacy.cuesoft.io/cueprise/).
+
+## The Cueprise™ platform
+
+Everything from here governs a licensed deployment rather than the website.
+
+### Access and authorised users
 
 1. Access to Cueprise™ is provisioned under a Licensee's agreement. If you
    sign in to Cueprise™, you do so as an **authorised user** of a Licensee —
@@ -28,7 +53,7 @@ Terms, which prevail over the general
    when the cause is resolved — notice and cure rights are as stated in
    the licensing agreement.
 
-## Licence and restrictions
+### Licence and restrictions
 
 1. The Licensee receives the non-exclusive, non-transferable right to use
    the modules, user counts and environments stated in its agreement, for
@@ -44,7 +69,7 @@ Terms, which prevail over the general
 3. Usage beyond the licensed scope (modules, seats, environments) is
    invoiced per the agreement or requires an amended order.
 
-## Licensee data
+### Licensee data
 
 1. **Licensee data remains the Licensee's.** All data a Licensee or its
    users put into Cueprise™ — records, files, configurations, outputs
@@ -58,7 +83,7 @@ Terms, which prevail over the general
    agreement provides; Cuesoft does not hold Licensee data hostage to a
    commercial dispute.
 
-## The platform
+### The platform
 
 1. **Cueprise™ and all Cuesoft platforms remain Cuesoft's exclusive
    intellectual property** — software, source code, architecture,
@@ -71,7 +96,7 @@ Terms, which prevail over the general
    evolve functionality, and will not materially degrade licensed
    functionality during a paid term.
 
-## Storefronts
+### Storefronts
 
 Cueprise™ can power a Licensee's public online store. A storefront is
 **the Licensee's own service**: it runs under the Licensee's brand, its
@@ -83,13 +108,13 @@ Paystack under the Licensee's arrangement with it. How shopper data is
 handled inside the platform is described in the
 [Cueprise™ Privacy Notice](https://privacy.cuesoft.io/cueprise/).
 
-## Fees
+### Fees
 
 Licence fees, payment schedules, taxes and late-payment consequences are
 stated in each licensing agreement. **No Cueprise™ fees are published on
 or payable through the Websites.**
 
-## Confidentiality, liability, law
+### Confidentiality, liability, law
 
 The licensing agreement's confidentiality, warranty, indemnity,
 limitation-of-liability, term, termination and governing-law clauses govern

--- a/legal/intellectual-property/README.md
+++ b/legal/intellectual-property/README.md
@@ -34,7 +34,7 @@ it.
   pre-existing tools, libraries and know-how remain Cuesoft's.
 - **Cueprise™** remains Cuesoft's exclusive property; licensee data
   remains the licensee's — see the
-  [Cueprise™ Platform Terms](../../cueprise/).
+  [Cueprise™ Terms](../../cueprise/).
 
 ## Infringement notices
 


### PR DESCRIPTION
cueprise.cuesoft.io is about to link its footer and demo form directly at `terms.cuesoft.io/cueprise/` rather than the root, so that page has to answer for the site the reader is standing on — not only the licensed platform.

- Adds a **The Cueprise™ website** section: what the site is for, that a demo request creates no contract, that no fee is quoted and no payment taken, with acceptable use incorporated from [Using the Websites](../websites/) rather than duplicated.
- Nests the existing platform terms under **The Cueprise™ platform** so the two halves are symmetric.
- Renames the page Cueprise™ Terms, since it is no longer platform-only.

Built clean; every internal link resolves.