### PR TITLE
chore: add Cuesoft project manifest

### DIFF
--- a/.cuesoft/project.yaml
+++ b/.cuesoft/project.yaml
@@ -1,0 +1,14 @@
+schemaVersion: 1
+name: terms
+profile: base
+
+surfaces:
+  static-docs: active
+
+capabilities:
+  mitLicense: active
+
+deployment:
+  static-docs: github-pages
+
+deviations: []


### PR DESCRIPTION
## Summary
- Adds `.cuesoft/project.yaml` declaring terms as a base-profile static-docs surface (GitHub Pages).

## Test plan
- [x] `cuesoft_standard.py audit` on this repo